### PR TITLE
Simplify CleanupFn

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ if err != nil {
     t.Fatalf("configuration error: %v ", err)
 }
 
-// subscribe to SNS and cleanup at the end
-receive, cleanup := snstesting.New(t, cfg, topicName)
-defer cleanup()
+// subscribe to SNS, all resources created here will be cleaned up at the end of the test
+receive := snstesting.New(t, cfg, topicName)
 
 // fire your process here, whatever it is ;)
 

--- a/snstesting.go
+++ b/snstesting.go
@@ -53,14 +53,6 @@ func New(t *testing.T, cfg aws.Config, topicName string) ReceiveFn {
 		t.Fatal(err)
 	}
 
-	receiveFn := func() string {
-		msg, err := s.Receive(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return msg
-	}
-
 	t.Cleanup(func() {
 		err := s.Cleanup(ctx)
 		if err != nil {
@@ -68,7 +60,13 @@ func New(t *testing.T, cfg aws.Config, topicName string) ReceiveFn {
 		}
 	})
 
-	return receiveFn
+	return func() string {
+		msg, err := s.Receive(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return msg
+	}
 }
 
 // NewSubscriber creates Subscriber instance for ad-hoc subscribing to SNS topic.

--- a/snstesting.go
+++ b/snstesting.go
@@ -38,6 +38,7 @@ type Config struct {
 type ReceiveFn func() string
 
 // New creates Subscriber for testing purposes based on provided AWS configuration.
+// Ad-hoc resources are cleaned up after the test automatically with use of t.Cleanup.
 // In case of an error, t.Fatal is executed.
 // In case more control is needed over Subscriber, or it's Config, please use NewSubscriber.
 func New(t *testing.T, cfg aws.Config, topicName string) ReceiveFn {


### PR DESCRIPTION
Get rid of CleanupFn due to built-in `t.Cleanup`